### PR TITLE
fix github actions yaml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: golangci-lint
 on:
   push:
     tags:
-      - *:v*
+      - "*:v*"
     branches:
       - master
       - main


### PR DESCRIPTION
Fix github actions yaml as `:` would affect the yaml parser.